### PR TITLE
Add environment variable 'PRINTING_MAILHOST_FIXED_ADDRESS'.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,17 @@ Changelog
 0.8 (unreleased)
 ----------------
 
+- Add environment variable ``PRINTING_MAILHOST_FIXED_ADDRESS`` to send
+  all emails to a single, fixed address.  PrintingMailHost still needs
+  to be enabled, so this is in addition to printing.
+  https://github.com/collective/Products.PrintingMailHost/issues/2
+  [maurits]
+
 - Since we can enable PMH via an environment variable and thus when not
   running in debug mode / foreground, emails are no longer printed, but
   written to the zope event log.
   [pysailor]
+
 
 0.7 (2010-01-05)
 ----------------

--- a/Products/PrintingMailHost/__init__.py
+++ b/Products/PrintingMailHost/__init__.py
@@ -7,7 +7,7 @@ LOG = logging.getLogger('PrintingMailHost')
 
 TRUISMS = ['yes', 'y', 'true', 'on']
 ENABLED = os.environ.get('ENABLE_PRINTING_MAILHOST', None)
-
+FIXED_ADDRESS = os.environ.get('PRINTING_MAILHOST_FIXED_ADDRESS', '')
 # check to see if the environment var is set to a 'true' value
 if (ENABLED is not None and ENABLED.lower() in TRUISMS) or \
    (ENABLED is None and DevelopmentMode is True):

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,23 @@ buildout, you can do this:
         ...
         ENABLE_PRINTING_MAILHOST False
 
+- If PrintingMailHost is enabled, and you *additionally* want to send
+  each email to a fixed address, you can add another environment
+  variable::
+
+    [instance]
+    ...
+    environment-vars =
+        ...
+        PRINTING_MAILHOST_FIXED_ADDRESS admin@example.org
+
+  For clarity: this first prints the email, with the original
+  recipient address, and then sends an actual email with the same
+  contents to the fixed address you have specified.  The original
+  recipient is visible in the ``To:`` field.  It is similar to
+  receiving a blind carbon copy (bcc) of an email, except that the
+  original recipient never gets the email.
+
 - Re-run buildout in order to make any of the above changes active::
 
     $ ./bin/buildout

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,6 +4,7 @@ develop = .
 parts =
     instance
     instance2
+    instance3
 
 [instance]
 recipe = plone.recipe.zope2instance
@@ -18,3 +19,11 @@ eggs =
 # variable.
 environment-vars =
     ENABLE_PRINTING_MAILHOST yes
+
+[instance3]
+<= instance
+# An instance where we send all emails to a fixed address.
+# Note that you still need need to enable the printing mailhost either
+# via an extra environment variable, or by running in debug mode.
+environment-vars =
+    PRINTING_MAILHOST_FIXED_ADDRESS admin@example.org


### PR DESCRIPTION
This sends all emails to a single, fixed address.  PrintingMailHost
still needs to be enabled, so this is in addition to printing.

See issue https://github.com/collective/Products.PrintingMailHost/issues/2
