### PR TITLE
init settings from environment as late as possible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Check environment variables in Zope2 `initialize` instead of import time.
+  This allows to configure environment-vars in zope.conf and use them when
+  starting the instance with slc.zopescript
+  [fRiSi]
 
 1.0 (2016-09-20)
 ----------------

--- a/Products/PrintingMailHost/__init__.py
+++ b/Products/PrintingMailHost/__init__.py
@@ -2,21 +2,26 @@ from Globals import DevelopmentMode
 import logging
 import os
 
-LOG = logging.getLogger('PrintingMailHost')
-
+LOG = None
+ENABLED = None
+FIXED_ADDRESS = []
 
 TRUISMS = ['yes', 'y', 'true', 'on']
-ENABLED = os.environ.get('ENABLE_PRINTING_MAILHOST', None)
-FIXED_ADDRESS = os.environ.get('PRINTING_MAILHOST_FIXED_ADDRESS', '')
-# Treat as a list:
-FIXED_ADDRESS = [addr for addr in FIXED_ADDRESS.strip().split(' ') if addr]
-# check to see if the environment var is set to a 'true' value
-if (ENABLED is not None and ENABLED.lower() in TRUISMS) or \
-   (ENABLED is None and DevelopmentMode is True):
-    LOG.warning("Hold on to your hats folks, I'm a-patchin'")
-    import Patch
-    Patch  # pyflakes
 
 
 def initialize(context):
-    pass
+    global LOG
+    global FIXED_ADDRESS
+    global ENABLED
+    LOG = logging.getLogger('PrintingMailHost')
+
+    ENABLED = os.environ.get('ENABLE_PRINTING_MAILHOST', None)
+    addresses = os.environ.get('PRINTING_MAILHOST_FIXED_ADDRESS', '')
+    FIXED_ADDRESS = [addr for addr in addresses.strip().split(' ') if addr]
+
+    # check to see if the environment var is set to a 'true' value
+    if (ENABLED is not None and ENABLED.lower() in TRUISMS) or \
+       (ENABLED is None and DevelopmentMode is True):
+        LOG.warning("Hold on to your hats folks, I'm a-patchin'")
+        import Patch
+        Patch  # pyflakes

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,8 @@ Clayton Parker <clayton (AT) sixfeetup (DOT) com>
 
 Maurits van Rees <maurits (AT) vanrees (DOT) org>
 
+Harald Friessnegger <harald (AT) webmeisterei (DOT) com>
+
 
 Products.PrintingMailHost Installation
 ======================================


### PR DESCRIPTION
this allows to configure environment variables in zope.conf and
use `slc.zopescript <https://github.com/syslabcom/slc.zopescript>` to
startup the instance.