### PR TITLE
fix: maybe some typo, was missing bracket, so fixed the syntax error

### DIFF
--- a/Products/PrintingMailHost/Patch.py
+++ b/Products/PrintingMailHost/Patch.py
@@ -72,9 +72,8 @@ class PrintingMailHost:
             else:
                 try:
                     messageText.set_payload(decodestring(body))    
-                except TypeError: # Python 3
-                    messageText.set_payload(decodestring(body).encode("utf8") 
-                                              
+                except TypeError:  # Python 3
+                    messageText.set_payload(decodestring(body).encode("utf8"))
         print(messageText, file=out)
         print(" ---- done ---- ", file=out)
         print("", file=out)


### PR DESCRIPTION
When trying the latest master on my local I was getting error like this:
`Products.PrintingMailHost/Products/PrintingMailHost/Patch.py", line 77
    print(messageText, file=out)
    ^
SyntaxError: invalid syntax
`
