### PR TITLE
Add tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 #
 # EditorConfig Configuration file, for more details see:

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [flake8]
 doctests = 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 version: 2
 updates:

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,16 +1,10 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Meta
+
 on:
   push:
-    branches:
-      - master
-      - main
-  pull_request:
-    branches:
-      - master
-      - main
   workflow_dispatch:
 
 ##

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,10 +1,11 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Tests
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -19,7 +20,7 @@ jobs:
         - ["ubuntu", "ubuntu-latest"]
         config:
         # [Python version, visual name, tox env]
-        - ["3.13", "6.2 on py3.13", "py313-plone62"]
+        - ["3.14", "6.2 on py3.14", "py314-plone62"]
         - ["3.10", "6.2 on py3.10", "py310-plone62"]
 
     runs-on: ${{ matrix.os[1] }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 # python related
 *.egg-info

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,9 +1,9 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "2.3.1"
+commit-id = "2.6.1.dev0"
 
 [tox]
 test_matrix = {"6.2" = ["*"]}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 ci:
     autofix_prs: false
@@ -10,13 +10,13 @@ repos:
     rev: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py310-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 7.0.0
+    rev: 8.0.1
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.11.0
+    rev: 26.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
@@ -62,7 +62,7 @@ repos:
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
-    rev: "5.0"
+    rev: "5.0.1"
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ about how to use it.
 
 ## Compatibility
 
-Works on Plone 6.2 (in Python 3.10-3.13).
+Works on Plone 6.2 (in Python 3.10-3.14).
 
 ## Author
 

--- a/news/+623a86df.feature.md
+++ b/news/+623a86df.feature.md
@@ -1,0 +1,3 @@
+Add functions `apply_patches` and `undo_patches`.
+`apply_patches` is called at Zope startup.
+@mauritsvanrees

--- a/news/+85e1b39d.tests.md
+++ b/news/+85e1b39d.tests.md
@@ -1,3 +1,3 @@
 Add tests.
-Use the new `apply_patches` andd `undo_patches`  to help in these tests, without the patches bleeding over into other tests.
+Use the new `apply_patches` and `undo_patches`  to help in these tests, without the patches bleeding over into other tests.
 @mauritsvanrees

--- a/news/+85e1b39d.tests.md
+++ b/news/+85e1b39d.tests.md
@@ -1,0 +1,3 @@
+Add tests.
+Use the new `apply_patches` andd `undo_patches`  to help in these tests, without the patches bleeding over into other tests.
+@mauritsvanrees

--- a/news/+f748abd0.bugfix.md
+++ b/news/+f748abd0.bugfix.md
@@ -1,0 +1,1 @@
+Sending to a fixed address will happen immediately, if asked.  @mauritsvanrees

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
-requires = ["setuptools>=68.2,<80", "wheel"]
+requires = ["setuptools>=68.2,<83", "wheel"]
+
+
 
 [tool.towncrier]
 directory = "news/"
@@ -14,32 +16,32 @@ underlines = ["", "", ""]
 
 [[tool.towncrier.type]]
 directory = "breaking"
-name = "Breaking changes:"
+name = "Breaking changes"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "feature"
-name = "New features:"
+name = "New features"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "bugfix"
-name = "Bug fixes:"
+name = "Bug fixes"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "internal"
-name = "Internal:"
+name = "Internal"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "documentation"
-name = "Documentation:"
+name = "Documentation"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "tests"
-name = "Tests:"
+name = "Tests"
 showcontent = true
 
 ##
@@ -62,7 +64,7 @@ profile = "plone"
 ##
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py310"]
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     keywords="zope debug mailhost",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from setuptools import setup
 
-
 long_description = Path("README.md").read_text() + "\n" + Path("CHANGES.md").read_text()
 
 version = "2.0.2.dev0"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 long_description = Path("README.md").read_text() + "\n" + Path("CHANGES.md").read_text()
 
-version = "2.0.2.dev0"
+version = "2.1.0.dev0"
 
 setup(
     name="Products.PrintingMailHost",

--- a/setup.py
+++ b/setup.py
@@ -35,4 +35,11 @@ setup(
         "Products.MailHost",
         "Zope",
     ],
+    extras_require={
+        "test": [
+            "plone.app.testing",
+            "plone.testing",
+            "Products.CMFCore",
+        ]
+    },
 )

--- a/src/Products/PrintingMailHost/Patch.py
+++ b/src/Products/PrintingMailHost/Patch.py
@@ -151,34 +151,35 @@ See https://pypi.org/project/Products.PrintingMailHost
 """
 LOG.warning(warning)
 
-monkeyPatch(MailBase, PrintingMailHost)
-_patched_classes = [MailBase]
-# Patch some other mail host implementations.
+_mailhost_classes = [MailBase]
+# Search for some other mail host implementations.
 try:
     from Products.SecureMailHost.SecureMailHost import SecureMailBase
 except ImportError:
     pass
 else:
-    monkeyPatch(SecureMailBase, PrintingMailHost)
-    _patched_classes.append(SecureMailBase)
+    _mailhost_classes.append(SecureMailBase)
 
 try:
     from Products.MaildropHost.MaildropHost import MaildropHost
 except ImportError:
     pass
 else:
-    monkeyPatch(MaildropHost, PrintingMailHost)
-    _patched_classes.append(MaildropHost)
+    _mailhost_classes.append(MaildropHost)
 
 try:
     from Products.SecureMaildropHost.SecureMaildropHost import SecureMaildropHost
 except ImportError:
     pass
 else:
-    monkeyPatch(SecureMaildropHost, PrintingMailHost)
-    _patched_classes.append(SecureMaildropHost)
+    _mailhost_classes.append(SecureMaildropHost)
 
 
-def undoPatches():
-    for klass in _patched_classes:
+def apply_patches():
+    for klass in _mailhost_classes:
+        monkeyPatch(klass, PrintingMailHost)
+
+
+def undo_patches():
+    for klass in _mailhost_classes:
         undoMonkeyPatch(klass, PrintingMailHost)

--- a/src/Products/PrintingMailHost/Patch.py
+++ b/src/Products/PrintingMailHost/Patch.py
@@ -37,6 +37,32 @@ def monkeyPatch(originalClass, patchingClass):
             setattr(originalClass, name, newAttr)
 
 
+def undoMonkeyPatch(originalClass, patchingClass):
+    """Undo monkey patch of original class with attributes from new class.
+
+    * Takes all attributes and methods except __doc__ and __module__
+      from patching class
+    * Restores original attributes that were saved as _monkey_name
+    """
+    for name, newAttr in patchingClass.__dict__.items():
+        # don't overwrite doc or module information
+        if name not in ("__doc__", "__module__", "__dict__"):
+            # safe the old attribute as __monkey_name if exists
+            # __dict__ doesn't show inherited attributes :/
+            current = getattr(originalClass, name, None)
+            if current is None:
+                # This was not patched.
+                continue
+            stored_orig_name = PATCH_PREFIX + name
+            stored_orig = getattr(originalClass, stored_orig_name, None)
+            if stored_orig is None:
+                # There is nothing to restore.
+                continue
+            # Restore the original.
+            setattr(originalClass, name, stored_orig)
+            delattr(originalClass, stored_orig_name)
+
+
 class PrintingMailHost:
     """MailHost which prints to output."""
 
@@ -126,7 +152,7 @@ See https://pypi.org/project/Products.PrintingMailHost
 LOG.warning(warning)
 
 monkeyPatch(MailBase, PrintingMailHost)
-
+_patched_classes = [MailBase]
 # Patch some other mail host implementations.
 try:
     from Products.SecureMailHost.SecureMailHost import SecureMailBase
@@ -134,6 +160,7 @@ except ImportError:
     pass
 else:
     monkeyPatch(SecureMailBase, PrintingMailHost)
+    _patched_classes.append(SecureMailBase)
 
 try:
     from Products.MaildropHost.MaildropHost import MaildropHost
@@ -141,6 +168,7 @@ except ImportError:
     pass
 else:
     monkeyPatch(MaildropHost, PrintingMailHost)
+    _patched_classes.append(MaildropHost)
 
 try:
     from Products.SecureMaildropHost.SecureMaildropHost import SecureMaildropHost
@@ -148,3 +176,9 @@ except ImportError:
     pass
 else:
     monkeyPatch(SecureMaildropHost, PrintingMailHost)
+    _patched_classes.append(SecureMaildropHost)
+
+
+def undoPatches():
+    for klass in _patched_classes:
+        undoMonkeyPatch(klass, PrintingMailHost)

--- a/src/Products/PrintingMailHost/Patch.py
+++ b/src/Products/PrintingMailHost/Patch.py
@@ -70,8 +70,31 @@ class PrintingMailHost:
 
     security.declarePrivate("_send")
 
-    def _send(self, mfrom, mto, messageText, debug=False, immediate=False):
-        """Send the message."""
+    def _send(self, mfrom, mto, messageText, immediate=False, debug=False):
+        """Send the message.
+
+        The various definitions of _send in Plone (mostly tests) are all:
+
+            def _send(self, mfrom, mto, messageText, immediate=False)
+
+        except in collective.MockMailHost, which has:
+
+            def _send(self, mfrom, mto, messageText, debug=False):
+
+        and it actually ignores the 'debug' keyword argument.
+
+        Originally we had as order: `debug=False, immediate=False`.
+        But `Products/MailHost/MailHost.py` does not use keyword arguments,
+        but calls:
+
+            self._send(mfrom, mto, msg, immediate)
+
+        With our original order this meant that only our debug argument was
+        affected by the last value that got passed, and immediate was always
+        False.  So I switched this around.  The effect can be seen in
+        test_fixed_address, where a ConnectionRefusedError should be raise
+        when we send immediately.
+        """
         orig_messageText = messageText
         if isinstance(messageText, bytes):
             messageText = message_from_bytes(messageText)
@@ -112,10 +135,13 @@ class PrintingMailHost:
             orig_send = getattr(self, PATCH_PREFIX + "_send", None)
             if orig_send is not None:
                 LOG.info("Sending actual email to %s", FIXED_ADDRESS)
-                # We do not pass the 'debug' and 'immediate' keyword
-                # arguments, because not all implementations accept
-                # both keyword arguments.
-                orig_send(mfrom, FIXED_ADDRESS, orig_messageText)
+                try:
+                    orig_send(
+                        mfrom, FIXED_ADDRESS, orig_messageText, immediate=immediate
+                    )
+                except TypeError:
+                    # Not all implementations accept the 'immediate' keyword argument.
+                    orig_send(mfrom, FIXED_ADDRESS, orig_messageText)
 
 
 warning = """

--- a/src/Products/PrintingMailHost/Patch.py
+++ b/src/Products/PrintingMailHost/Patch.py
@@ -7,7 +7,6 @@ from Products.MailHost.MailHost import MailBase
 from Products.PrintingMailHost import FIXED_ADDRESS
 from Products.PrintingMailHost import LOG
 
-
 PATCH_PREFIX = "_monkey_"
 
 __refresh_module__ = 0
@@ -102,15 +101,12 @@ Monkey patching MailHosts to print e-mails to the terminal.
 
 
 if FIXED_ADDRESS:
-    warning += (
-        """
+    warning += """
 Also, ALL MAIL WILL BE SENT TO ONE ADDRESS: %s
 
 Change PRINTING_MAILHOST_FIXED_ADDRESS in the environment variables
 to change the address, or remove it to only print the e-mails.
-"""
-        % FIXED_ADDRESS
-    )
+""" % FIXED_ADDRESS
 else:
     warning += """
 This is instead of sending them.

--- a/src/Products/PrintingMailHost/__init__.py
+++ b/src/Products/PrintingMailHost/__init__.py
@@ -28,6 +28,6 @@ def initialize(context):
         # DevelopmentMode is checked by plone.api
         DevelopmentMode = True  # noqa
         LOG.warning("Hold on to your hats folks, I'm a-patchin'")
-        from Products.PrintingMailHost import Patch
+        from Products.PrintingMailHost.Patch import apply_patches
 
-        Patch  # pyflakes
+        apply_patches()

--- a/src/Products/PrintingMailHost/__init__.py
+++ b/src/Products/PrintingMailHost/__init__.py
@@ -3,7 +3,6 @@ from App.config import getConfiguration
 import logging
 import os
 
-
 LOG = None
 ENABLED = None
 FIXED_ADDRESS = []

--- a/src/Products/PrintingMailHost/testing.py
+++ b/src/Products/PrintingMailHost/testing.py
@@ -12,6 +12,13 @@ class PrintingMailHostFixture(PloneSandboxLayer):
         os.environ["ENABLE_PRINTING_MAILHOST"] = "yes"
         zope.installProduct(app, "Products.PrintingMailHost")
 
+    def tearDownZope(self, app):
+        from Products.PrintingMailHost.Patch import undoPatches
+
+        undoPatches()
+        breakpoint()
+        zope.uninstallProduct(app, "Products.PrintingMailHost")
+
 
 PRINTINGMAILHOST_FIXTURE = PrintingMailHostFixture()
 

--- a/src/Products/PrintingMailHost/testing.py
+++ b/src/Products/PrintingMailHost/testing.py
@@ -1,0 +1,20 @@
+from plone.app.testing import IntegrationTesting
+from plone.app.testing import PloneSandboxLayer
+from plone.testing import zope
+
+import os
+
+
+class PrintingMailHostFixture(PloneSandboxLayer):
+    # defaultBases = (AUTOLOGIN_LIBRARY_FIXTURE,)
+
+    def setUpZope(self, app, configurationContext):
+        os.environ["ENABLE_PRINTING_MAILHOST"] = "yes"
+        zope.installProduct(app, "Products.PrintingMailHost")
+
+
+PRINTINGMAILHOST_FIXTURE = PrintingMailHostFixture()
+
+PRINTINGMAILHOST_INTEGRATION_TESTING = IntegrationTesting(
+    bases=(PRINTINGMAILHOST_FIXTURE,), name="PrintingMailHost:Integration"
+)

--- a/src/Products/PrintingMailHost/testing.py
+++ b/src/Products/PrintingMailHost/testing.py
@@ -4,8 +4,6 @@ from plone.testing import zope
 
 
 class PrintingMailHostFixture(PloneSandboxLayer):
-    # defaultBases = (AUTOLOGIN_LIBRARY_FIXTURE,)
-
     def setUpZope(self, app, configurationContext):
         zope.installProduct(app, "Products.PrintingMailHost")
 

--- a/src/Products/PrintingMailHost/testing.py
+++ b/src/Products/PrintingMailHost/testing.py
@@ -2,21 +2,17 @@ from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
 from plone.testing import zope
 
-import os
-
 
 class PrintingMailHostFixture(PloneSandboxLayer):
     # defaultBases = (AUTOLOGIN_LIBRARY_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
-        os.environ["ENABLE_PRINTING_MAILHOST"] = "yes"
         zope.installProduct(app, "Products.PrintingMailHost")
 
     def tearDownZope(self, app):
-        from Products.PrintingMailHost.Patch import undoPatches
+        from Products.PrintingMailHost.Patch import undo_patches
 
-        undoPatches()
-        breakpoint()
+        undo_patches()
         zope.uninstallProduct(app, "Products.PrintingMailHost")
 
 

--- a/src/Products/PrintingMailHost/tests.py
+++ b/src/Products/PrintingMailHost/tests.py
@@ -7,6 +7,18 @@ import unittest
 class TestIntegration(unittest.TestCase):
     layer = PRINTINGMAILHOST_INTEGRATION_TESTING
 
+    def setUp(self) -> None:
+        from Products.PrintingMailHost.Patch import apply_patches
+
+        apply_patches()
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        from Products.PrintingMailHost.Patch import undo_patches
+
+        undo_patches()
+        return super().tearDown()
+
     def send(self):
         mailhost = getToolByName(self.layer["portal"], "MailHost")
         mailhost.send(
@@ -28,9 +40,9 @@ class TestIntegration(unittest.TestCase):
             self.assertIn("message text", output)
 
     def test_unpatch(self):
-        from Products.PrintingMailHost.Patch import undoPatches
+        from Products.PrintingMailHost.Patch import undo_patches
 
-        undoPatches()
+        undo_patches()
         with self.assertNoLogs("PrintingMailHost", level="INFO"):
             with self.assertRaises(ConnectionRefusedError):
                 self.send()

--- a/src/Products/PrintingMailHost/tests.py
+++ b/src/Products/PrintingMailHost/tests.py
@@ -1,0 +1,25 @@
+from Products.CMFCore.utils import getToolByName
+from Products.PrintingMailHost.testing import PRINTINGMAILHOST_INTEGRATION_TESTING
+
+import unittest
+
+
+class TestIntegration(unittest.TestCase):
+    layer = PRINTINGMAILHOST_INTEGRATION_TESTING
+
+    def test_add_missing_uuids(self):
+        mailhost = getToolByName(self.layer["portal"], "MailHost")
+        with self.assertLogs("PrintingMailHost", level="INFO") as logs:
+            mailhost.send(
+                "message text",
+                mfrom="me@example.org",
+                mto="you@example.org",
+                subject="Hello",
+                immediate=True,
+            )
+            self.assertEqual(len(logs.output), 1)
+            output = logs.output[0]
+            self.assertIn("From: me@example.org", output)
+            self.assertIn("To: you@example.org", output)
+            self.assertIn("Subject: Hello", output)
+            self.assertIn("message text", output)

--- a/src/Products/PrintingMailHost/tests.py
+++ b/src/Products/PrintingMailHost/tests.py
@@ -46,7 +46,8 @@ class TestIntegration(unittest.TestCase):
         Patch.FIXED_ADDRESS = ["another@example.org"]
         try:
             with self.assertLogs("PrintingMailHost", level="INFO") as logs:
-                self.send()
+                with self.assertRaises(ConnectionRefusedError):
+                    self.send()
                 self.assertEqual(len(logs.output), 2)
                 output = logs.output[0]
                 self.assertIn("From: me@example.org", output)

--- a/src/Products/PrintingMailHost/tests.py
+++ b/src/Products/PrintingMailHost/tests.py
@@ -7,19 +7,30 @@ import unittest
 class TestIntegration(unittest.TestCase):
     layer = PRINTINGMAILHOST_INTEGRATION_TESTING
 
-    def test_add_missing_uuids(self):
+    def send(self):
         mailhost = getToolByName(self.layer["portal"], "MailHost")
+        mailhost.send(
+            "message text",
+            mfrom="me@example.org",
+            mto="you@example.org",
+            subject="Hello",
+            immediate=True,
+        )
+
+    def test_output(self):
         with self.assertLogs("PrintingMailHost", level="INFO") as logs:
-            mailhost.send(
-                "message text",
-                mfrom="me@example.org",
-                mto="you@example.org",
-                subject="Hello",
-                immediate=True,
-            )
+            self.send()
             self.assertEqual(len(logs.output), 1)
             output = logs.output[0]
             self.assertIn("From: me@example.org", output)
             self.assertIn("To: you@example.org", output)
             self.assertIn("Subject: Hello", output)
             self.assertIn("message text", output)
+
+    def test_unpatch(self):
+        from Products.PrintingMailHost.Patch import undoPatches
+
+        undoPatches()
+        with self.assertNoLogs("PrintingMailHost", level="INFO"):
+            with self.assertRaises(ConnectionRefusedError):
+                self.send()

--- a/src/Products/PrintingMailHost/tests.py
+++ b/src/Products/PrintingMailHost/tests.py
@@ -39,6 +39,26 @@ class TestIntegration(unittest.TestCase):
             self.assertIn("Subject: Hello", output)
             self.assertIn("message text", output)
 
+    def test_fixed_address(self):
+        from Products.PrintingMailHost import Patch
+
+        orig_fixed_address = Patch.FIXED_ADDRESS
+        Patch.FIXED_ADDRESS = ["another@example.org"]
+        try:
+            with self.assertLogs("PrintingMailHost", level="INFO") as logs:
+                self.send()
+                self.assertEqual(len(logs.output), 2)
+                output = logs.output[0]
+                self.assertIn("From: me@example.org", output)
+                self.assertIn("To: you@example.org", output)
+                self.assertIn("Subject: Hello", output)
+                self.assertIn("message text", output)
+                self.assertIn(
+                    "Sending actual email to ['another@example.org']", logs.output[1]
+                )
+        finally:
+            Patch.FIXED_ADDRESS = orig_fixed_address
+
     def test_unpatch(self):
         from Products.PrintingMailHost.Patch import undo_patches
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [tox]
 # We need 4.4.0 for constrain_package_deps.
@@ -7,6 +7,7 @@ min_version = 4.4.0
 envlist =
     lint
     test
+    py314-plone62
     py313-plone62
     py312-plone62
     py311-plone62
@@ -18,6 +19,7 @@ envlist =
 # Add extra configuration options in .meta.toml:
 # - to specify a custom testing combination of Plone and python versions, use `test_matrix`
 #   Use ["*"] to use all supported Python versions for this Plone version.
+# - to disable the test matrix entirely, set `use_test_matrix = false`
 # - to specify extra custom environments, use `envlist_lines`
 # - to specify extra `tox` top-level options, use `config_lines`
 #  [tox]
@@ -62,6 +64,7 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
+    setuptools<82.0.0
     z3c.dependencychecker==2.14.3
 commands =
     python -m build --sdist
@@ -130,6 +133,7 @@ extras =
 ##
 # Add extra configuration options in .meta.toml:
 #  [tox]
+#  skip_test_extra = true
 #  test_extras = """
 #      tests
 #      widgets


### PR DESCRIPTION
* Add functions `apply_patches` and `undo_patches`.  `apply_patches` is called at Zope startup.
* Add tests. Use the new `apply_patches` andd `undo_patches`  to help in these tests, without the patches bleeding over into other tests (like the coredev ecosystem tests).
* Bugfix: Sending to a fixed address will happen immediately, if asked.

Main reason for me to look at this, is https://github.com/plone/meta/issues/325: a recent tox will fail with error "extras not found" if the "test" extra that `tox.ini` tries to use is not there.  This is the case for `Products.PrintingMailHost`.
The real problem here, is that this package actually has no tests.  Latest [test run on master](https://github.com/collective/Products.PrintingMailHost/actions/runs/20436492731/job/58718929071#step:7:24) passes with this message:

```
Total: 0 tests, 0 failures, 0 errors and 0 skipped in 0.000 seconds.
```

So I added some tests.  This actually brought to light a small bug with sending to a fixed address, which I fixed.
